### PR TITLE
Add HTMX + Alpine sample modal for Sedes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# empleados-web
+# Empleados Web
+
+Interfaz HTML para la gestión de recursos humanos.
+
+## Desarrollo
+
+Este proyecto no utiliza un sistema de build. Para probar las interacciones dinámicas basadas en [HTMX](https://htmx.org) y [Alpine.js](https://alpinejs.dev), sirve el sitio con un servidor local, por ejemplo:
+
+```bash
+python -m http.server
+```
+
+Luego abre `config.html` en tu navegador.

--- a/config.html
+++ b/config.html
@@ -5,6 +5,8 @@
 <title>Usuario / Configuración</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="stylesheet" href="styles.css">
+<script src="https://unpkg.com/htmx.org@1.9.12"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body>
 <a class="skip-link" href="#main">Saltar al contenido</a>
@@ -73,14 +75,24 @@
     </div>
 
     <!-- SEDES -->
-    <div class="card">
+    <div class="card" x-data="{open:false}">
       <h2>Sedes</h2>
       <div class="row">
         <div><label>Nombre de la Sede</label><input id="siteName" placeholder="Sede Lima"></div>
       </div>
       <div class="actions">
         <button id="btnSiteAdd">Agregar</button>
-        <button class="secondary" id="btnSitesView">Ver todo</button>
+        <button class="secondary" hx-get="partials/sites-list.html" hx-target="#sitesModalBody" @click="open=true">Ver todo</button>
+      </div>
+
+      <div x-cloak x-bind:class="open ? 'modal-backdrop open' : 'modal-backdrop'" @click.self="open=false">
+        <div class="modal">
+          <header>
+            <h3>Listado de Sedes</h3>
+            <button @click="open=false" aria-label="Cerrar">✖</button>
+          </header>
+          <div id="sitesModalBody">Cargando…</div>
+        </div>
       </div>
     </div>
 
@@ -398,7 +410,6 @@ window.addEventListener('DOMContentLoaded', async () => {
       showMsg('ok','Sede creada.'); await reloadSites();
     }catch(e){ showMsg('err',`Error al crear sede: ${e.message}`); }
   });
-  $('btnSitesView')   && $('btnSitesView').addEventListener('click', ()=> openSitesModal());
 
   $('btnProjAdd')     && $('btnProjAdd').addEventListener('click', async ()=>{
     try{

--- a/partials/sites-list.html
+++ b/partials/sites-list.html
@@ -1,0 +1,9 @@
+<table>
+  <thead>
+    <tr><th>ID</th><th>Nombre</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1</td><td>Sede Lima</td></tr>
+    <tr><td>2</td><td>Sede Cusco</td></tr>
+  </tbody>
+</table>

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,8 @@ a:focus-visible,button:focus-visible,input:focus-visible,select:focus-visible{ou
 .small{font-size:12px;color:#6b7280;}
 /* Modal */
 .modal-backdrop{position:fixed;inset:0;background:#0005;display:none;align-items:center;justify-content:center;z-index:50;}
+.modal-backdrop.open{display:flex;}
+[x-cloak]{display:none!important;}
 .modal{background:#fff;border-radius:14px;max-width:900px;width:90%;max-height:80vh;overflow:auto;padding:16px;box-shadow:0 4px 10px rgba(0,0,0,.1);}
 .modal header{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;gap:10px;}
 .modal input[type="search"]{width:260px;padding:8px;border-radius:8px;border:1px solid #d1d5db;background:#fff;color:var(--text);}


### PR DESCRIPTION
## Summary
- load htmx and Alpine from CDN
- add Sedes modal powered by Alpine and populated via HTMX
- include basic styles and example partial
- document running a simple server for dynamic interactions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a96281b8832fa23f5125e6a9b2b1